### PR TITLE
Add recurring tasks

### DIFF
--- a/src/main/java/profplan/logic/commands/DescriptionCommand.java
+++ b/src/main/java/profplan/logic/commands/DescriptionCommand.java
@@ -54,6 +54,7 @@ public class DescriptionCommand extends Command {
 
         Task taskToEdit = lastShownList.get(index.getZeroBased());
         Task editedTask = new Task(taskToEdit.getName(), taskToEdit.getPriority(),
+                taskToEdit.getIsRecurring(), taskToEdit.getRecurringType(),
                 taskToEdit.getTags(), taskToEdit.getDueDate(),
                 taskToEdit.getChildren(), taskToEdit.getLink(), description);
 

--- a/src/main/java/profplan/logic/commands/EditCommand.java
+++ b/src/main/java/profplan/logic/commands/EditCommand.java
@@ -103,7 +103,8 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editTaskDescriptor.getTags().orElse(taskToEdit.getTags());
         Set<Task> updatedChildren = editTaskDescriptor.getChildren().orElse(taskToEdit.getChildren());
         DueDate updatedDueDate = editTaskDescriptor.getDueDate().orElse(taskToEdit.getDueDate());
-        return new Task(updatedName, updatedPriority, updatedTags,
+        return new Task(updatedName, updatedPriority, taskToEdit.getIsRecurring(),
+                taskToEdit.getRecurringType(), updatedTags,
                         updatedDueDate, updatedChildren, updatedLink, taskToEdit.getDescription());
     }
 

--- a/src/main/java/profplan/logic/commands/SetCommand.java
+++ b/src/main/java/profplan/logic/commands/SetCommand.java
@@ -58,6 +58,7 @@ public class SetCommand extends Command {
         Set<Task> addedSet = parentTask.getChildren();
         addedSet.add(childTask);
         Task editedTask = new Task(parentTask.getName(), parentTask.getPriority(),
+                parentTask.getIsRecurring(), parentTask.getRecurringType(),
                 parentTask.getTags(), parentTask.getDueDate(), addedSet,
                 parentTask.getLink(), parentTask.getDescription());
 

--- a/src/main/java/profplan/logic/parser/AddCommandParser.java
+++ b/src/main/java/profplan/logic/parser/AddCommandParser.java
@@ -6,6 +6,7 @@ import static profplan.logic.parser.CliSyntax.PREFIX_DUEDATE;
 import static profplan.logic.parser.CliSyntax.PREFIX_LINK;
 import static profplan.logic.parser.CliSyntax.PREFIX_NAME;
 import static profplan.logic.parser.CliSyntax.PREFIX_PRIORITY;
+import static profplan.logic.parser.CliSyntax.PREFIX_RECURRING;
 import static profplan.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
@@ -35,7 +36,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_RECURRING,
                         PREFIX_TAG, PREFIX_DUEDATE, PREFIX_LINK, PREFIX_DESCRIPTION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
@@ -44,15 +45,18 @@ public class AddCommandParser implements Parser<AddCommand> {
                 + AddCommand.MESSAGE_DETAILS + AddCommand.MESSAGE_EXAMPLE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PRIORITY);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PRIORITY, PREFIX_RECURRING);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Priority priority = (argMultimap.getValue(PREFIX_PRIORITY) == Optional.<String>empty()) ? new Priority("000")
                 : ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         DueDate dueDate = ParserUtil.parseDueDate(argMultimap.getValue(PREFIX_DUEDATE).orElse("No due date"));
         Link link = ParserUtil.parseLink(argMultimap.getValue(PREFIX_LINK).orElse("-"));
+        boolean isRecurring = argMultimap.getValue(PREFIX_RECURRING).isPresent();
+        Task.RecurringType recurringType = isRecurring
+                ? ParserUtil.parseRecurringType(argMultimap.getValue(PREFIX_RECURRING).get()) : null;
 
-        Task task = new Task(name, priority, tagList, dueDate, new HashSet<>(),
+        Task task = new Task(name, priority, isRecurring, recurringType, tagList, dueDate, new HashSet<>(),
                 link, new Description(""));
         return new AddCommand(task);
     }

--- a/src/main/java/profplan/logic/parser/CliSyntax.java
+++ b/src/main/java/profplan/logic/parser/CliSyntax.java
@@ -8,6 +8,7 @@ public class CliSyntax {
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PRIORITY = new Prefix("p/");
+    public static final Prefix PREFIX_RECURRING = new Prefix("recur/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_STATUS = new Prefix("s/");
     public static final Prefix PREFIX_LINK = new Prefix("l/");

--- a/src/main/java/profplan/logic/parser/ParserUtil.java
+++ b/src/main/java/profplan/logic/parser/ParserUtil.java
@@ -15,6 +15,7 @@ import profplan.model.task.Link;
 import profplan.model.task.Name;
 import profplan.model.task.Priority;
 import profplan.model.task.Status;
+import profplan.model.task.Task;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -136,5 +137,37 @@ public class ParserUtil {
             throw new ParseException(DueDate.MESSAGE_CONSTRAINTS);
         }
         return new DueDate(trimmedDate);
+    }
+
+    /**
+     * Parses a {@code RecurringTask}.
+     *
+     * @throws ParseException if the given {@code String} is invalid.
+     */
+    public static Task.RecurringType parseRecurringType(String input) throws ParseException {
+        requireNonNull(input);
+        String processedInput = input.trim().toLowerCase();
+
+        switch (processedInput) {
+
+        case "daily":
+        case "d":
+            return Task.RecurringType.DAILY;
+
+        case "weekly":
+        case "w":
+            return Task.RecurringType.WEEKLY;
+
+        case "monthly":
+        case "m":
+            return Task.RecurringType.MONTHLY;
+
+        default:
+            throw new ParseException("The input should be one of the following:\n"
+                    + "'daily', 'weekly', 'monthly', or the shortforms 'd', 'w', 'm',"
+                    + "case insensitive.");
+
+        }
+
     }
 }

--- a/src/main/java/profplan/model/task/DueDate.java
+++ b/src/main/java/profplan/model/task/DueDate.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -128,9 +130,34 @@ public class DueDate implements Comparable<DueDate> {
         return !parsedDate.before(currentDay) && !parsedDate.after(endOfMonth);
     }
 
+    /**
+     * Increments a DueDate by the number of days specified.
+     * @param dueDate The DueDate to increment
+     * @param days The number of days to increment by. Must be between 0-31.
+     * @return A new DueDate object, with the incremented value.
+     */
+    public DueDate addDays(DueDate dueDate, long days) {
+        requireNonNull(dueDate);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+        LocalDate date = LocalDate.parse(value, dateTimeFormatter);
+        return new DueDate(date.plusDays(days).format(dateTimeFormatter));
+    }
+
+    /**
+     * Increments a DueDate by 1 month.
+     * @param dueDate The DueDate to increment
+     * @return A new DueDate object, with the incremented value.
+     */
+    public DueDate addMonth(DueDate dueDate) {
+        requireNonNull(dueDate);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+        LocalDate date = LocalDate.parse(value, dateTimeFormatter);
+        return new DueDate(date.plusMonths(1).format(dateTimeFormatter));
+    }
+
     @Override
     public String toString() {
-        return value;
+        return parsedValue == null ? value : format.format(parsedValue);
     }
 
     @Override

--- a/src/main/java/profplan/model/task/Task.java
+++ b/src/main/java/profplan/model/task/Task.java
@@ -18,45 +18,77 @@ public class Task implements Comparable<Task> {
     // Identity fields
     private final Name name;
     private final Priority priority;
+    private final boolean isRecurringTask;
+    private final RecurringType recurringType;
 
     // Data fields
     private final Link link;
     private Status status;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Task> children = new HashSet<>();
-    private final DueDate dueDate;
+    private DueDate dueDate;
     private final Description description;
+
+    /**
+     * Encapsulates the different types of recurring Tasks.
+     */
+    public enum RecurringType {
+        DAILY("Daily"), WEEKLY("Weekly"), MONTHLY("Monthly");
+
+        private final String name;
+        RecurringType(String name) {
+            this.name = name;
+        }
+        private String getName() {
+            return name;
+        }
+    }
 
     /**
      * Every field except status must be present and not null.
      */
-    public Task(Name name, Priority priority,
-                Set<Tag> tags, DueDate dueDate, Set<Task> children, Link link, Description description) {
+    public Task(Name name, Priority priority, boolean isRecurringTask, RecurringType recurringType,
+                Set<Tag> tags, DueDate dueDate, Set<Task> children,
+                Link link, Description description) {
         CollectionUtil.requireAllNonNull(name, priority, tags, dueDate);
         this.name = name;
         this.priority = priority;
+        this.isRecurringTask = isRecurringTask;
+        this.recurringType = recurringType;
         this.status = Status.UNDONE_STATUS;
         this.tags.addAll(tags);
         this.children.addAll(children);
         this.dueDate = dueDate;
         this.link = link;
         this.description = description;
+
+        if (isRecurringTask) {
+            this.tags.add(new Tag(recurringType.getName()));
+        }
     }
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present
      */
-    public Task(Name name, Priority priority, Status status, Set<Tag> tags,
+    public Task(Name name, Priority priority, boolean isRecurringTask, RecurringType recurringType,
+                Status status,
+                Set<Tag> tags,
                 DueDate dueDate, Set<Task> children, Link link, Description description) {
         CollectionUtil.requireAllNonNull(name, priority, tags, dueDate);
         this.name = name;
         this.priority = priority;
+        this.isRecurringTask = isRecurringTask;
+        this.recurringType = recurringType;
         this.status = status;
         this.tags.addAll(tags);
         this.dueDate = dueDate;
         this.children.addAll(children);
         this.link = link;
         this.description = description;
+
+        if (isRecurringTask) {
+            this.tags.add(new Tag(recurringType.getName()));
+        }
     }
 
     /**
@@ -66,6 +98,8 @@ public class Task implements Comparable<Task> {
     public Task(Task task) {
         this.name = task.name;
         this.priority = task.priority;
+        this.isRecurringTask = task.isRecurringTask;
+        this.recurringType = task.recurringType;
         this.tags.addAll(task.getTags());
         this.children.addAll(task.getChildren());
         this.status = task.status;
@@ -82,6 +116,14 @@ public class Task implements Comparable<Task> {
         return priority;
     }
 
+    public boolean getIsRecurring() {
+        return isRecurringTask;
+    }
+
+    public RecurringType getRecurringType() {
+        return recurringType;
+    }
+
     public Link getLink() {
         return link;
     }
@@ -95,7 +137,30 @@ public class Task implements Comparable<Task> {
     }
 
     public void setStatus(Status status) {
-        this.status = status;
+        if (status == Status.DONE_STATUS && this.isRecurringTask) {
+
+            switch (recurringType) {
+
+            case DAILY:
+                dueDate = dueDate.addDays(dueDate, 1);
+                break;
+
+            case WEEKLY:
+                dueDate = dueDate.addDays(dueDate, 7);
+                break;
+
+            case MONTHLY:
+                dueDate = dueDate.addMonth(dueDate);
+                break;
+
+            default:
+                throw new RuntimeException("Execution should not reach this point.");
+
+            }
+
+        } else {
+            this.status = status;
+        }
     }
 
     /**

--- a/src/main/java/profplan/model/util/SampleDataUtil.java
+++ b/src/main/java/profplan/model/util/SampleDataUtil.java
@@ -21,22 +21,22 @@ import profplan.model.task.Task;
 public class SampleDataUtil {
     public static Task[] getSampleTasks() {
         return new Task[] {
-            new Task(new Name("Alex Yeoh"), new Priority("4"),
+            new Task(new Name("Alex Yeoh"), new Priority("4"), false, null,
                     getTagSet("friends"), new DueDate("01-01-2000"), new HashSet<>(), new Link("-"),
                     new Description("")),
-            new Task(new Name("Bernice Yu"), new Priority("2"),
+            new Task(new Name("Bernice Yu"), new Priority("2"), false, null,
                     getTagSet("colleagues", "friends"), new DueDate("01-01-2000"), new HashSet<>(),
                     new Link("-"), new Description("")),
-            new Task(new Name("Charlotte Oliveiro"), new Priority("3"),
+            new Task(new Name("Charlotte Oliveiro"), new Priority("3"), false, null,
                     getTagSet("neighbours"), new DueDate("01-01-2000"), new HashSet<>(),
                     new Link("-"), new Description("")),
-            new Task(new Name("David Li"), new Priority("10"),
+            new Task(new Name("David Li"), new Priority("10"), false, null,
                     getTagSet("family"), new DueDate("01-01-2000"), new HashSet<>(),
                     new Link("-"), new Description("")),
-            new Task(new Name("Irfan Ibrahim"), new Priority("6"),
+            new Task(new Name("Irfan Ibrahim"), new Priority("6"), false, null,
                     getTagSet("classmates"), new DueDate("01-01-2000"), new HashSet<>(),
                     new Link("-"), new Description("")),
-            new Task(new Name("Roy Balakrishnan"), new Priority("9"),
+            new Task(new Name("Roy Balakrishnan"), new Priority("9"), false, null,
                     getTagSet("colleagues"), new DueDate("01-01-2000"), new HashSet<>(),
                     new Link("-"), new Description(""))
         };

--- a/src/main/java/profplan/storage/JsonAdaptedTask.java
+++ b/src/main/java/profplan/storage/JsonAdaptedTask.java
@@ -28,6 +28,8 @@ class JsonAdaptedTask {
 
     private final String name;
     private final String priority;
+    private final boolean isRecurring;
+    private final Task.RecurringType recurringType;
     private final String dueDate;
     private final String status;
     private final String link;
@@ -40,12 +42,16 @@ class JsonAdaptedTask {
      */
     @JsonCreator
     public JsonAdaptedTask(@JsonProperty("name") String name, @JsonProperty("priority") String priority,
-                           @JsonProperty("tags") List<JsonAdaptedTag> tags,
+            @JsonProperty("isRecurring") boolean isRecurring,
+            @JsonProperty("recurringType") Task.RecurringType recurringType,
+            @JsonProperty("tags") List<JsonAdaptedTag> tags,
             @JsonProperty("status") String status, @JsonProperty("dueDate") String dueDate,
             @JsonProperty("children") List<JsonAdaptedTask> children, @JsonProperty("link") String link,
             @JsonProperty("description") String description) {
         this.name = name;
         this.priority = priority;
+        this.isRecurring = isRecurring;
+        this.recurringType = recurringType;
         this.dueDate = dueDate;
         this.status = status;
         this.link = link;
@@ -64,6 +70,8 @@ class JsonAdaptedTask {
     public JsonAdaptedTask(Task source) {
         name = source.getName().fullName;
         priority = source.getPriority().value;
+        isRecurring = source.getIsRecurring();
+        recurringType = source.getRecurringType();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -109,6 +117,10 @@ class JsonAdaptedTask {
         }
         final Priority modelPriority = new Priority(priority);
 
+        final boolean modelIsRecurring = isRecurring;
+
+        final Task.RecurringType modelRecurringType = recurringType;
+
         final Set<Tag> modelTags = new HashSet<>(taskTags);
 
         String linkToLoad = link;
@@ -139,7 +151,8 @@ class JsonAdaptedTask {
         }
         final Description modelDescription = new Description(description);
 
-        return new Task(modelName, modelPriority, modelStatus, modelTags, modelDueDate,
+        return new Task(modelName, modelPriority, modelIsRecurring, modelRecurringType,
+                modelStatus, modelTags, modelDueDate,
                 modelChildren, modelLink, modelDescription);
     }
 

--- a/src/test/java/profplan/storage/JsonAdaptedTaskTest.java
+++ b/src/test/java/profplan/storage/JsonAdaptedTaskTest.java
@@ -42,7 +42,7 @@ public class JsonAdaptedTaskTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedTask task = new JsonAdaptedTask(INVALID_NAME, VALID_PRIORITY,
+        JsonAdaptedTask task = new JsonAdaptedTask(INVALID_NAME, VALID_PRIORITY, false, null,
                 VALID_TAGS, "undone", VALID_DUEDATE, VALID_CHILDREN,
                 null, VALID_DESCRIPTION);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
@@ -51,7 +51,7 @@ public class JsonAdaptedTaskTest {
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedTask task = new JsonAdaptedTask(null, VALID_PRIORITY,
+        JsonAdaptedTask task = new JsonAdaptedTask(null, VALID_PRIORITY, false, null,
                 VALID_TAGS, "undone", VALID_DUEDATE, VALID_CHILDREN,
                 null, VALID_DESCRIPTION);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
@@ -60,7 +60,7 @@ public class JsonAdaptedTaskTest {
 
     @Test
     public void toModelType_invalidPriority_throwsIllegalValueException() {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, INVALID_PRIORITY,
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, INVALID_PRIORITY, false, null,
                 VALID_TAGS, "undone", VALID_DUEDATE, VALID_CHILDREN,
                 null, VALID_DESCRIPTION);
         String expectedMessage = Priority.MESSAGE_CONSTRAINTS;
@@ -70,7 +70,7 @@ public class JsonAdaptedTaskTest {
     @Test
 
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, null,
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, null, false, null,
                 VALID_TAGS, "undone", VALID_DUEDATE, VALID_CHILDREN,
                 null, VALID_DESCRIPTION);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Priority.class.getSimpleName());
@@ -81,14 +81,14 @@ public class JsonAdaptedTaskTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, VALID_PRIORITY,
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, VALID_PRIORITY, false, null,
                 invalidTags, "undone", VALID_DUEDATE, VALID_CHILDREN, null, VALID_DESCRIPTION);
         Assert.assertThrows(IllegalValueException.class, task::toModelType);
     }
 
     @Test
     public void toModelType_invalidDueDate_throwsIllegalValueException() {
-        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, VALID_PRIORITY,
+        JsonAdaptedTask task = new JsonAdaptedTask(VALID_NAME, VALID_PRIORITY, false, null,
                 VALID_TAGS, "undone", INVALID_DUEDATE, VALID_CHILDREN,
                 null, VALID_DESCRIPTION);
         String expectedMessage = DueDate.MESSAGE_CONSTRAINTS;

--- a/src/test/java/profplan/testutil/TaskBuilder.java
+++ b/src/test/java/profplan/testutil/TaskBuilder.java
@@ -19,6 +19,8 @@ public class TaskBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PRIORITY = "85355255";
+    public static final boolean DEFAULT_RECURRING = false;
+    public static final Task.RecurringType DEFAULT_RECURRING_TYPE = null;
     public static final String DEFAULT_DUEDATE = "01-01-2000";
     public static final String DEFAULT_LINK = "-";
     public static final String DEFUALT_DESCRIPTION = "";
@@ -26,6 +28,8 @@ public class TaskBuilder {
 
     private Name name;
     private Priority priority;
+    private boolean isRecurring;
+    private Task.RecurringType recurringType;
     private Set<Tag> tags;
     private Set<Task> children;
     private DueDate dueDate;
@@ -38,6 +42,8 @@ public class TaskBuilder {
     public TaskBuilder() {
         name = new Name(DEFAULT_NAME);
         priority = new Priority(DEFAULT_PRIORITY);
+        isRecurring = DEFAULT_RECURRING;
+        recurringType = DEFAULT_RECURRING_TYPE;
         tags = new HashSet<>();
         children = new HashSet<>();
         dueDate = new DueDate(DEFAULT_DUEDATE);
@@ -110,7 +116,7 @@ public class TaskBuilder {
      * Builds a new task with the given fields.
      */
     public Task build() {
-        return new Task(name, priority, tags, dueDate, children,
+        return new Task(name, priority, isRecurring, recurringType, tags, dueDate, children,
                 link, description);
     }
 


### PR DESCRIPTION
The `add` command can now support the `recur/` flag, with possible arguments:
- `daily`
- `weekly`
- `monthly`
and the shortforms `d`, `w`, `m`, case insensitive. Tasks are automatically tagged with the appropriate recurring label, and `mark` will not mark them done, but instead push back the deadline.

Closes #92.