### PR TITLE
Add settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/main/resources/docs/
 /data/
 /config.json
 /preferences.json
+/settings.json
 /*.log.*
 hs_err_pid[0-9]*.log
 

--- a/src/main/java/profplan/MainApp.java
+++ b/src/main/java/profplan/MainApp.java
@@ -222,7 +222,7 @@ public class MainApp extends Application {
             logger.severe("Failed to save user preferences " + StringUtil.getDetails(e));
         }
         try {
-            storage.saveUserConfigs(model.getUserConfigs());
+            storage.saveUserConfigs(ModelManager.getUserConfigs());
         } catch (IOException e) {
             logger.severe("Failed to save user configs " + StringUtil.getDetails(e));
         }

--- a/src/main/java/profplan/MainApp.java
+++ b/src/main/java/profplan/MainApp.java
@@ -219,7 +219,12 @@ public class MainApp extends Application {
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {
-            logger.severe("Failed to save preferences " + StringUtil.getDetails(e));
+            logger.severe("Failed to save user preferences " + StringUtil.getDetails(e));
+        }
+        try {
+            storage.saveUserConfigs(model.getUserConfigs());
+        } catch (IOException e) {
+            logger.severe("Failed to save user configs " + StringUtil.getDetails(e));
         }
     }
 }

--- a/src/main/java/profplan/commons/core/Config.java
+++ b/src/main/java/profplan/commons/core/Config.java
@@ -17,6 +17,7 @@ public class Config {
     // Config values customizable through config file
     private Level logLevel = Level.INFO;
     private Path userPrefsFilePath = Paths.get("preferences.json");
+    private Path userConfigsFilePath = Paths.get("settings.json");
 
     public Level getLogLevel() {
         return logLevel;
@@ -32,6 +33,12 @@ public class Config {
 
     public void setUserPrefsFilePath(Path userPrefsFilePath) {
         this.userPrefsFilePath = userPrefsFilePath;
+    }
+    public Path getUserConfigsFilePath() {
+        return userConfigsFilePath;
+    }
+    public void setUserConfigsFilePath(Path userConfigsFilePath) {
+        this.userConfigsFilePath = userConfigsFilePath;
     }
 
     @Override

--- a/src/main/java/profplan/commons/core/Settings.java
+++ b/src/main/java/profplan/commons/core/Settings.java
@@ -12,7 +12,7 @@ import profplan.logic.parser.Prefix;
  */
 public class Settings implements Serializable {
     // array containing all keywords used to specify these fields. contain these keywords in Prefixes.
-    public static final Prefix[] keywords = {new Prefix("semesterDays")};
+    public static final Prefix[] KEYWORDS = {new Prefix("semesterDays")};
 
     // default values
     private static final int DEFAULT_SEMESTER_DAYS = 180;

--- a/src/main/java/profplan/commons/core/Settings.java
+++ b/src/main/java/profplan/commons/core/Settings.java
@@ -4,12 +4,15 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import profplan.commons.util.ToStringBuilder;
+import profplan.logic.parser.Prefix;
 
 /**
  * A Serializable class that contains the general settings.
  * Guarantees: immutable.
  */
 public class Settings implements Serializable {
+    // array containing all keywords used to specify these fields. contain these keywords in Prefixes.
+    public static final Prefix[] keywords = {new Prefix("semesterDays")};
 
     // default values
     private static final int DEFAULT_SEMESTER_DAYS = 180;

--- a/src/main/java/profplan/commons/core/Settings.java
+++ b/src/main/java/profplan/commons/core/Settings.java
@@ -1,0 +1,66 @@
+package profplan.commons.core;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import profplan.commons.util.ToStringBuilder;
+
+/**
+ * A Serializable class that contains the general settings.
+ * Guarantees: immutable.
+ */
+public class Settings implements Serializable {
+
+    // default values
+    private static final int DEFAULT_SEMESTER_DAYS = 180;
+
+    // fields
+    private final int semesterDays;
+
+    /**
+     * Constructs a {@code Settings} with default settings.
+     */
+    public Settings() {
+        semesterDays = DEFAULT_SEMESTER_DAYS;
+    }
+
+    /**
+     * Constructs a {@code Settings} with the specified settings.
+     */
+    public Settings(int semesterDays) {
+        this.semesterDays = semesterDays;
+    }
+
+    // getters
+    public int getSemesterDays() {
+        return semesterDays;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Settings)) {
+            return false;
+        }
+
+        Settings otherSettings = (Settings) other;
+        return this.semesterDays == otherSettings.semesterDays;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(semesterDays);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("semesterDays", semesterDays)
+                .toString();
+    }
+
+}

--- a/src/main/java/profplan/logic/commands/EditSettingsCommand.java
+++ b/src/main/java/profplan/logic/commands/EditSettingsCommand.java
@@ -9,6 +9,7 @@ import profplan.commons.core.Settings;
 import profplan.commons.util.ToStringBuilder;
 import profplan.logic.commands.exceptions.CommandException;
 import profplan.model.Model;
+import profplan.model.ModelManager;
 import profplan.model.ReadOnlyUserConfigs;
 
 /**
@@ -51,12 +52,12 @@ public class EditSettingsCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ReadOnlyUserConfigs userConfigs = model.getUserConfigs();
+        ReadOnlyUserConfigs userConfigs = ModelManager.getUserConfigs();
 
         Settings settingsToEdit = userConfigs.getSettings();
         Settings editedSettings = createEditedSettings(settingsToEdit, editSettingsDescriptor);
 
-        model.setSettings(editedSettings);
+        ModelManager.setSettings(editedSettings);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/profplan/logic/commands/EditSettingsCommand.java
+++ b/src/main/java/profplan/logic/commands/EditSettingsCommand.java
@@ -1,0 +1,138 @@
+package profplan.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import profplan.commons.core.Settings;
+import profplan.commons.util.ToStringBuilder;
+import profplan.logic.commands.exceptions.CommandException;
+import profplan.model.Model;
+import profplan.model.ReadOnlyUserConfigs;
+
+/**
+ * Edits the details of an existing setting in the user configs.
+ */
+public class EditSettingsCommand extends Command {
+
+    public static final String COMMAND_WORD = "set";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the value of a specified configuration"
+            + "parameter in the user config files to the input value.";
+
+    public static final String MESSAGE_DETAILS = "Existing values will be overwritten by the input values.\n"
+            + "Parameters: settingField, the setting to be altered;"
+            + "and value, the new value to be set";
+
+    public static final String MESSAGE_EXAMPLE = "Example: " + COMMAND_WORD + " semesterDays "
+            + "100 ";
+
+    public static final String MESSAGE_SUCCESS = "Settings successfully updated!";
+
+    private final EditSettingsDescriptor editSettingsDescriptor;
+
+    /**
+     * @param editSettingsDescriptor details to edit the settings with
+     */
+    public EditSettingsCommand(EditSettingsDescriptor editSettingsDescriptor) {
+        requireNonNull(editSettingsDescriptor);
+
+        this.editSettingsDescriptor = new EditSettingsDescriptor(editSettingsDescriptor);
+    }
+
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ReadOnlyUserConfigs userConfigs = model.getUserConfigs();
+
+        Settings settingsToEdit = userConfigs.getSettings();
+        Settings editedSettings = createEditedSettings(settingsToEdit, editSettingsDescriptor);
+
+        model.setSettings(editedSettings);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    private Settings createEditedSettings(Settings settingsToEdit,
+                                          EditSettingsDescriptor editSettingsDescriptor) {
+        assert settingsToEdit != null;
+
+        Integer semesterDays = editSettingsDescriptor.getSemesterDays()
+                .orElse(settingsToEdit.getSemesterDays());
+
+        return new Settings(semesterDays);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditSettingsCommand)) {
+            return false;
+        }
+
+        EditSettingsCommand otherEditSettingsCommand = (EditSettingsCommand) other;
+        return editSettingsDescriptor.equals(otherEditSettingsCommand.editSettingsDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("editSettingsDescriptor", editSettingsDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the settings with. The non-empty field value will replace
+     * the corresponding setting value.
+     */
+    public static class EditSettingsDescriptor {
+        private Integer semesterDays;
+
+        public EditSettingsDescriptor() {}
+
+        public EditSettingsDescriptor(EditSettingsDescriptor toCopy) {
+            setSemesterDays(toCopy.semesterDays);
+        }
+
+        public void setSemesterDays(int semesterDays) {
+            this.semesterDays = semesterDays;
+        }
+
+        public Optional<Integer> getSemesterDays() {
+            return Optional.ofNullable(semesterDays);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditSettingsDescriptor)) {
+                return false;
+            }
+
+            EditSettingsDescriptor otherEditSettingsDescriptor = (EditSettingsDescriptor) other;
+            return Objects.equals(semesterDays, otherEditSettingsDescriptor.semesterDays);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("semesterDays", semesterDays)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/profplan/logic/parser/EditCommandParser.java
+++ b/src/main/java/profplan/logic/parser/EditCommandParser.java
@@ -31,7 +31,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_TAG, PREFIX_DUEDATE, PREFIX_LINK);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_TAG, PREFIX_DUEDATE,
+                        PREFIX_LINK);
         Index index;
 
         try {

--- a/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
+++ b/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
@@ -1,0 +1,36 @@
+package profplan.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import profplan.commons.core.Settings;
+import profplan.logic.commands.EditSettingsCommand;
+import profplan.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditSettingsCommand object
+ */
+public class EditSettingsCommandParser implements Parser<EditSettingsCommand> {
+    /**
+     * Parses {@code userInput} into a command and returns it.
+     *
+     * @param userInput
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    @Override
+    public EditSettingsCommand parse(String userInput) throws ParseException {
+        requireNonNull(userInput);
+        Prefix[] keywords = Settings.keywords;
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, keywords);
+
+        EditSettingsCommand.EditSettingsDescriptor editSettingsDescriptor =
+                new EditSettingsCommand.EditSettingsDescriptor();
+
+        // semesterDays
+        if (argumentMultimap.getValue(keywords[0]).isPresent()) {
+            editSettingsDescriptor.setSemesterDays(ParserUtil
+                    .parseInteger(argumentMultimap.getValue(keywords[0]).get()));
+        }
+
+        return new EditSettingsCommand(editSettingsDescriptor);
+    }
+}

--- a/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
+++ b/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
@@ -19,7 +19,7 @@ public class EditSettingsCommandParser implements Parser<EditSettingsCommand> {
     @Override
     public EditSettingsCommand parse(String userInput) throws ParseException {
         requireNonNull(userInput);
-        Prefix[] keywords = Settings.keywords;
+        Prefix[] keywords = Settings.KEYWORDS;
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(userInput, keywords);
 
         EditSettingsCommand.EditSettingsDescriptor editSettingsDescriptor =

--- a/src/main/java/profplan/logic/parser/ParserUtil.java
+++ b/src/main/java/profplan/logic/parser/ParserUtil.java
@@ -162,9 +162,13 @@ public class ParserUtil {
         case "m":
             return Task.RecurringType.MONTHLY;
 
+        case "semesterly":
+        case "s":
+            return Task.RecurringType.SEMESTERLY;
+
         default:
             throw new ParseException("The input should be one of the following:\n"
-                    + "'daily', 'weekly', 'monthly', or the shortforms 'd', 'w', 'm',"
+                    + "'daily', 'weekly', 'monthly', 'semesterly', or the shortforms 'd', 'w', 'm', 's'\n"
                     + "case insensitive.");
 
         }

--- a/src/main/java/profplan/logic/parser/ParserUtil.java
+++ b/src/main/java/profplan/logic/parser/ParserUtil.java
@@ -170,4 +170,15 @@ public class ParserUtil {
         }
 
     }
+
+    /**
+     * Checks if a String is a valid integer and returns the int if so.
+     */
+    public static int parseInteger(String input) throws ParseException {
+        try {
+            return Integer.parseInt(input.trim());
+        } catch (NumberFormatException e) {
+            throw new ParseException(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/profplan/logic/parser/ProfPlanParser.java
+++ b/src/main/java/profplan/logic/parser/ProfPlanParser.java
@@ -15,6 +15,7 @@ import profplan.logic.commands.DeleteCommand;
 import profplan.logic.commands.DescriptionCommand;
 import profplan.logic.commands.DoNextCommand;
 import profplan.logic.commands.EditCommand;
+import profplan.logic.commands.EditSettingsCommand;
 import profplan.logic.commands.ExitCommand;
 import profplan.logic.commands.FilterCommand;
 import profplan.logic.commands.FindCommand;
@@ -23,7 +24,6 @@ import profplan.logic.commands.ListCommand;
 import profplan.logic.commands.ListMonthCommand;
 import profplan.logic.commands.ListWeekCommand;
 import profplan.logic.commands.MarkCommand;
-import profplan.logic.commands.SetCommand;
 import profplan.logic.commands.SortDueDateCommand;
 import profplan.logic.commands.SortPriorityCommand;
 import profplan.logic.commands.UnmarkCommand;
@@ -69,6 +69,9 @@ public class ProfPlanParser {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
+        case EditSettingsCommand.COMMAND_WORD:
+            return new EditSettingsCommandParser().parse(arguments);
+
         case MarkCommand.COMMAND_WORD:
             return new MarkCommandParser().parse(arguments);
 
@@ -99,9 +102,6 @@ public class ProfPlanParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommandParser().parse(arguments);
 
-        case SetCommand.COMMAND_WORD:
-            return new SetCommandParser().parse(arguments);
-
         case DescriptionCommand.COMMAND_WORD:
             return new DescriptionCommandParser().parse(arguments);
 
@@ -120,7 +120,6 @@ public class ProfPlanParser {
                 logger.finer("This user input caused a ParseException: " + userInput);
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
-
 
         case ListWeekCommand.COMMAND_WORD:
             return new ListWeekCommand();

--- a/src/main/java/profplan/model/Model.java
+++ b/src/main/java/profplan/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import profplan.commons.core.GuiSettings;
+import profplan.commons.core.Settings;
 import profplan.model.task.Task;
 
 /**
@@ -43,6 +44,26 @@ public interface Model {
      * Sets the user prefs' task list file path.
      */
     void setProfPlanFilePath(Path profPlanFilePath);
+
+    /**
+     * Replaces user configs data with the data in {@code userConfigs}.
+     */
+    void setUserConfigs(ReadOnlyUserConfigs userConfigs);
+
+    /**
+     * Returns the user configs.
+     */
+    ReadOnlyUserConfigs getUserConfigs();
+
+    /**
+     * Returns the user configs' settings.
+     */
+    Settings getSettings();
+
+    /**
+     * Sets the user configs' settings.
+     */
+    void setSettings(Settings settings);
 
     /**
      * Replaces task list data with the data in {@code profPlan}.

--- a/src/main/java/profplan/model/Model.java
+++ b/src/main/java/profplan/model/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import profplan.commons.core.GuiSettings;
-import profplan.commons.core.Settings;
 import profplan.model.task.Task;
 
 /**
@@ -44,26 +43,6 @@ public interface Model {
      * Sets the user prefs' task list file path.
      */
     void setProfPlanFilePath(Path profPlanFilePath);
-
-    /**
-     * Replaces user configs data with the data in {@code userConfigs}.
-     */
-    void setUserConfigs(ReadOnlyUserConfigs userConfigs);
-
-    /**
-     * Returns the user configs.
-     */
-    ReadOnlyUserConfigs getUserConfigs();
-
-    /**
-     * Returns the user configs' settings.
-     */
-    Settings getSettings();
-
-    /**
-     * Sets the user configs' settings.
-     */
-    void setSettings(Settings settings);
 
     /**
      * Replaces task list data with the data in {@code profPlan}.

--- a/src/main/java/profplan/model/ModelManager.java
+++ b/src/main/java/profplan/model/ModelManager.java
@@ -15,6 +15,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import profplan.commons.core.GuiSettings;
 import profplan.commons.core.LogsCenter;
+import profplan.commons.core.Settings;
 import profplan.commons.util.CollectionUtil;
 import profplan.model.task.DueDate;
 import profplan.model.task.Priority;
@@ -29,23 +30,26 @@ public class ModelManager implements Model {
 
     private final ProfPlan profPlan;
     private final UserPrefs userPrefs;
+    private final UserConfigs userConfigs;
     private final FilteredList<Task> filteredTasks;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
-    public ModelManager(ReadOnlyProfPlan addressBook, ReadOnlyUserPrefs userPrefs) {
+    public ModelManager(ReadOnlyProfPlan addressBook, ReadOnlyUserPrefs userPrefs,
+                        ReadOnlyUserConfigs userConfigs) {
         CollectionUtil.requireAllNonNull(addressBook, userPrefs);
 
         logger.fine("Initializing with task list: " + addressBook + " and user prefs " + userPrefs);
 
         this.profPlan = new ProfPlan(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
+        this.userConfigs = new UserConfigs(userConfigs);
         filteredTasks = new FilteredList<>(this.profPlan.getTaskList());
     }
 
     public ModelManager() {
-        this(new ProfPlan(), new UserPrefs());
+        this(new ProfPlan(), new UserPrefs(), new UserConfigs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -81,6 +85,30 @@ public class ModelManager implements Model {
     public void setProfPlanFilePath(Path profPlanFilePath) {
         requireNonNull(profPlanFilePath);
         userPrefs.setProfPlanFilePath(profPlanFilePath);
+    }
+
+    //=========== UserPrefs ==================================================================================
+
+    @Override
+    public void setUserConfigs(ReadOnlyUserConfigs userConfigs) {
+        requireNonNull(userConfigs);
+        this.userConfigs.resetData(userConfigs);
+    }
+
+    @Override
+    public ReadOnlyUserConfigs getUserConfigs() {
+        return userConfigs;
+    }
+
+    @Override
+    public Settings getSettings() {
+        return userConfigs.getSettings();
+    }
+
+    @Override
+    public void setSettings(Settings settings) {
+        requireNonNull(settings);
+        userConfigs.setSettings(settings);
     }
 
     //=========== ProfPlan ================================================================================

--- a/src/main/java/profplan/model/ModelManager.java
+++ b/src/main/java/profplan/model/ModelManager.java
@@ -87,7 +87,7 @@ public class ModelManager implements Model {
         userPrefs.setProfPlanFilePath(profPlanFilePath);
     }
 
-    //=========== UserPrefs ==================================================================================
+    //=========== UserConfigs ==================================================================================
 
     @Override
     public void setUserConfigs(ReadOnlyUserConfigs userConfigs) {

--- a/src/main/java/profplan/model/ModelManager.java
+++ b/src/main/java/profplan/model/ModelManager.java
@@ -26,11 +26,12 @@ import profplan.model.task.Task;
  * Represents the in-memory model of the task list data.
  */
 public class ModelManager implements Model {
+
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
+    private static UserConfigs userConfigs;
     private final ProfPlan profPlan;
     private final UserPrefs userPrefs;
-    private final UserConfigs userConfigs;
     private final FilteredList<Task> filteredTasks;
 
     /**
@@ -44,7 +45,7 @@ public class ModelManager implements Model {
 
         this.profPlan = new ProfPlan(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        this.userConfigs = new UserConfigs(userConfigs);
+        ModelManager.userConfigs = new UserConfigs(userConfigs);
         filteredTasks = new FilteredList<>(this.profPlan.getTaskList());
     }
 
@@ -89,24 +90,20 @@ public class ModelManager implements Model {
 
     //=========== UserConfigs ==================================================================================
 
-    @Override
-    public void setUserConfigs(ReadOnlyUserConfigs userConfigs) {
+    public static void setUserConfigs(ReadOnlyUserConfigs userConfigs) {
         requireNonNull(userConfigs);
-        this.userConfigs.resetData(userConfigs);
+        ModelManager.userConfigs.resetData(userConfigs);
     }
 
-    @Override
-    public ReadOnlyUserConfigs getUserConfigs() {
+    public static ReadOnlyUserConfigs getUserConfigs() {
         return userConfigs;
     }
 
-    @Override
-    public Settings getSettings() {
+    public static Settings getSettings() {
         return userConfigs.getSettings();
     }
 
-    @Override
-    public void setSettings(Settings settings) {
+    public static void setSettings(Settings settings) {
         requireNonNull(settings);
         userConfigs.setSettings(settings);
     }

--- a/src/main/java/profplan/model/ReadOnlyUserConfigs.java
+++ b/src/main/java/profplan/model/ReadOnlyUserConfigs.java
@@ -1,0 +1,16 @@
+package profplan.model;
+
+import java.nio.file.Path;
+
+import profplan.commons.core.Settings;
+
+/**
+ * Unmodifiable view of user prefs.
+ */
+public interface ReadOnlyUserConfigs {
+
+    Settings getSettings();
+
+    Path getProfPlanFilePath();
+
+}

--- a/src/main/java/profplan/model/UserConfigs.java
+++ b/src/main/java/profplan/model/UserConfigs.java
@@ -1,0 +1,88 @@
+package profplan.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import profplan.commons.core.Settings;
+
+/**
+ * Stores global settings used in various commands. These can be updated by the user.
+ */
+public class UserConfigs implements ReadOnlyUserConfigs {
+
+    private Settings settings = new Settings();
+    private Path profPlanFilePath = Paths.get("data" , "profplan.json");
+
+    /**
+     * Creates a {@code UserConfigs} with default values.
+     */
+    public UserConfigs() {}
+
+    /**
+     * Creates a {@code UserConfigs} with the prefs in {@code userConfigs}.
+     */
+    public UserConfigs(ReadOnlyUserConfigs userConfigs) {
+        this();
+        resetData(userConfigs);
+    }
+
+    /**
+     * Resets the existing data of this {@code UserConfigs} with {@code newUserConfigs}.
+     */
+    public void resetData(ReadOnlyUserConfigs newUserConfigs) {
+        requireNonNull(newUserConfigs);
+        setSettings(newUserConfigs.getSettings());
+        setProfPlanFilePath(newUserConfigs.getProfPlanFilePath());
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(Settings settings) {
+        requireNonNull(settings);
+        this.settings = settings;
+    }
+
+    public Path getProfPlanFilePath() {
+        return profPlanFilePath;
+    }
+
+    public void setProfPlanFilePath(Path profPlanFilePath) {
+        requireNonNull(profPlanFilePath);
+        this.profPlanFilePath = profPlanFilePath;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UserConfigs)) {
+            return false;
+        }
+
+        UserConfigs otherUserConfigs = (UserConfigs) other;
+        return settings.equals(otherUserConfigs.settings)
+                && profPlanFilePath.equals(otherUserConfigs.profPlanFilePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(settings, profPlanFilePath);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Settings : " + settings);
+        sb.append("\nLocal data file location : " + profPlanFilePath);
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/profplan/model/task/Task.java
+++ b/src/main/java/profplan/model/task/Task.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import profplan.commons.util.CollectionUtil;
 import profplan.commons.util.ToStringBuilder;
+import profplan.model.ModelManager;
 import profplan.model.tag.Tag;
 
 /**
@@ -33,7 +34,7 @@ public class Task implements Comparable<Task> {
      * Encapsulates the different types of recurring Tasks.
      */
     public enum RecurringType {
-        DAILY("Daily"), WEEKLY("Weekly"), MONTHLY("Monthly");
+        DAILY("Daily"), WEEKLY("Weekly"), MONTHLY("Monthly"), SEMESTERLY("Semesterly");
 
         private final String name;
         RecurringType(String name) {
@@ -151,6 +152,10 @@ public class Task implements Comparable<Task> {
 
             case MONTHLY:
                 dueDate = dueDate.addMonth(dueDate);
+                break;
+
+            case SEMESTERLY:
+                dueDate = dueDate.addDays(dueDate, ModelManager.getSettings().getSemesterDays());
                 break;
 
             default:

--- a/src/main/java/profplan/storage/JsonUserConfigsStorage.java
+++ b/src/main/java/profplan/storage/JsonUserConfigsStorage.java
@@ -1,0 +1,47 @@
+package profplan.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import profplan.commons.exceptions.DataLoadingException;
+import profplan.commons.util.JsonUtil;
+import profplan.model.ReadOnlyUserConfigs;
+import profplan.model.UserConfigs;
+
+/**
+ * A class to access UserConfigs stored in the hard disk as a json file
+ */
+public class JsonUserConfigsStorage implements UserConfigsStorage {
+
+    private Path filePath;
+
+    public JsonUserConfigsStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public Path getUserConfigsFilePath() {
+        return filePath;
+    }
+
+    @Override
+    public Optional<UserConfigs> readUserConfigs() throws DataLoadingException {
+        return readUserConfigs(filePath);
+    }
+
+    /**
+     * Similar to {@link #readUserConfigs()}
+     * @param configsFilePath location of the data. Cannot be null.
+     * @throws DataLoadingException if the file format is not as expected.
+     */
+    public Optional<UserConfigs> readUserConfigs(Path configsFilePath) throws DataLoadingException {
+        return JsonUtil.readJsonFile(configsFilePath, UserConfigs.class);
+    }
+
+    @Override
+    public void saveUserConfigs(ReadOnlyUserConfigs userConfigs) throws IOException {
+        JsonUtil.saveJsonFile(userConfigs, filePath);
+    }
+
+}

--- a/src/main/java/profplan/storage/Storage.java
+++ b/src/main/java/profplan/storage/Storage.java
@@ -6,19 +6,30 @@ import java.util.Optional;
 
 import profplan.commons.exceptions.DataLoadingException;
 import profplan.model.ReadOnlyProfPlan;
+import profplan.model.ReadOnlyUserConfigs;
 import profplan.model.ReadOnlyUserPrefs;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 
 /**
  * API of the Storage component
  */
-public interface Storage extends ProfPlanStorage, UserPrefsStorage {
+public interface Storage extends ProfPlanStorage, UserPrefsStorage, UserConfigsStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataLoadingException;
 
     @Override
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
+
+    @Override
+    Path getUserConfigsFilePath();
+
+    @Override
+    Optional<UserConfigs> readUserConfigs() throws DataLoadingException;
+
+    @Override
+    void saveUserConfigs(ReadOnlyUserConfigs userConfigs) throws IOException;
 
     @Override
     Path getProfPlanFilePath();

--- a/src/main/java/profplan/storage/StorageManager.java
+++ b/src/main/java/profplan/storage/StorageManager.java
@@ -8,7 +8,9 @@ import java.util.logging.Logger;
 import profplan.commons.core.LogsCenter;
 import profplan.commons.exceptions.DataLoadingException;
 import profplan.model.ReadOnlyProfPlan;
+import profplan.model.ReadOnlyUserConfigs;
 import profplan.model.ReadOnlyUserPrefs;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 
 /**
@@ -19,13 +21,16 @@ public class StorageManager implements Storage {
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private ProfPlanStorage profPlanStorage;
     private UserPrefsStorage userPrefsStorage;
+    private UserConfigsStorage userConfigsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code ProfPlanStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(ProfPlanStorage profPlanStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(ProfPlanStorage profPlanStorage, UserPrefsStorage userPrefsStorage,
+                          UserConfigsStorage userConfigsStorage) {
         this.profPlanStorage = profPlanStorage;
         this.userPrefsStorage = userPrefsStorage;
+        this.userConfigsStorage = userConfigsStorage;
     }
 
     // ================ UserPrefs methods ==============================
@@ -45,8 +50,24 @@ public class StorageManager implements Storage {
         userPrefsStorage.saveUserPrefs(userPrefs);
     }
 
+    // ================ UserPrefs methods ==============================
 
-    // ================ AddressBook methods ==============================
+    @Override
+    public Path getUserConfigsFilePath() {
+        return userConfigsStorage.getUserConfigsFilePath();
+    }
+
+    @Override
+    public Optional<UserConfigs> readUserConfigs() throws DataLoadingException {
+        return userConfigsStorage.readUserConfigs();
+    }
+
+    @Override
+    public void saveUserConfigs(ReadOnlyUserConfigs userConfigs) throws IOException {
+        userConfigsStorage.saveUserConfigs(userConfigs);
+    }
+
+    // ================ ProfPlan methods ==============================
 
     @Override
     public Path getProfPlanFilePath() {

--- a/src/main/java/profplan/storage/StorageManager.java
+++ b/src/main/java/profplan/storage/StorageManager.java
@@ -50,7 +50,7 @@ public class StorageManager implements Storage {
         userPrefsStorage.saveUserPrefs(userPrefs);
     }
 
-    // ================ UserPrefs methods ==============================
+    // ================ UserConfigs methods ==============================
 
     @Override
     public Path getUserConfigsFilePath() {

--- a/src/main/java/profplan/storage/UserConfigsStorage.java
+++ b/src/main/java/profplan/storage/UserConfigsStorage.java
@@ -1,0 +1,36 @@
+package profplan.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import profplan.commons.exceptions.DataLoadingException;
+import profplan.model.ReadOnlyUserConfigs;
+import profplan.model.UserConfigs;
+
+/**
+ * Represents a storage for {@link profplan.model.UserConfigs}.
+ */
+public interface UserConfigsStorage {
+
+    /**
+     * Returns the file path of the UserConfigs data file.
+     */
+    Path getUserConfigsFilePath();
+
+    /**
+     * Returns UserConfigs data from storage.
+     * Returns {@code Optional.empty()} if storage file is not found.
+     *
+     * @throws DataLoadingException if the loading of data from preference file failed.
+     */
+    Optional<UserConfigs> readUserConfigs() throws DataLoadingException;
+
+    /**
+     * Saves the given {@link ReadOnlyUserConfigs} to the storage.
+     * @param userConfigs cannot be null.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void saveUserConfigs(ReadOnlyUserConfigs userConfigs) throws IOException;
+
+}

--- a/src/test/java/profplan/logic/LogicManagerTest.java
+++ b/src/test/java/profplan/logic/LogicManagerTest.java
@@ -21,9 +21,11 @@ import profplan.logic.parser.exceptions.ParseException;
 import profplan.model.Model;
 import profplan.model.ModelManager;
 import profplan.model.ReadOnlyProfPlan;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.Task;
 import profplan.storage.JsonProfPlanStorage;
+import profplan.storage.JsonUserConfigsStorage;
 import profplan.storage.JsonUserPrefsStorage;
 import profplan.storage.StorageManager;
 import profplan.testutil.Assert;
@@ -45,7 +47,9 @@ public class LogicManagerTest {
         JsonProfPlanStorage addressBookStorage =
                 new JsonProfPlanStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonUserConfigsStorage userConfigsStorage = new JsonUserConfigsStorage(
+                temporaryFolder.resolve("userConfigs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage, userConfigsStorage);
         logic = new LogicManager(model, storage);
     }
 
@@ -120,7 +124,7 @@ public class LogicManagerTest {
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage) {
-        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs(), new UserConfigs());
         assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedModel);
     }
 
@@ -157,7 +161,9 @@ public class LogicManagerTest {
 
         JsonUserPrefsStorage userPrefsStorage =
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonUserConfigsStorage userConfigsStorage =
+                new JsonUserConfigsStorage(temporaryFolder.resolve("ExceptionUserConfigs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage, userConfigsStorage);
 
         logic = new LogicManager(model, storage);
 

--- a/src/test/java/profplan/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/profplan/logic/commands/AddCommandIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import profplan.logic.Messages;
 import profplan.model.Model;
 import profplan.model.ModelManager;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.Task;
 import profplan.testutil.TaskBuilder;
@@ -22,14 +23,14 @@ public class AddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
+        model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
     }
 
     @Test
     public void execute_newTask_success() {
         Task validTask = new TaskBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs(), new UserConfigs());
         expectedModel.addTask(validTask);
 
         assertCommandSuccess(new AddCommand(validTask), model,

--- a/src/test/java/profplan/logic/commands/AddCommandTest.java
+++ b/src/test/java/profplan/logic/commands/AddCommandTest.java
@@ -14,13 +14,11 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import profplan.commons.core.GuiSettings;
-import profplan.commons.core.Settings;
 import profplan.logic.Messages;
 import profplan.logic.commands.exceptions.CommandException;
 import profplan.model.Model;
 import profplan.model.ProfPlan;
 import profplan.model.ReadOnlyProfPlan;
-import profplan.model.ReadOnlyUserConfigs;
 import profplan.model.ReadOnlyUserPrefs;
 import profplan.model.task.Task;
 import profplan.testutil.Assert;
@@ -118,26 +116,6 @@ public class AddCommandTest {
 
         @Override
         public void setProfPlanFilePath(Path profPlanFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setUserConfigs(ReadOnlyUserConfigs userConfigs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserConfigs getUserConfigs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Settings getSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setSettings(Settings settings) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/profplan/logic/commands/AddCommandTest.java
+++ b/src/test/java/profplan/logic/commands/AddCommandTest.java
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import profplan.commons.core.GuiSettings;
+import profplan.commons.core.Settings;
 import profplan.logic.Messages;
 import profplan.logic.commands.exceptions.CommandException;
 import profplan.model.Model;
 import profplan.model.ProfPlan;
 import profplan.model.ReadOnlyProfPlan;
+import profplan.model.ReadOnlyUserConfigs;
 import profplan.model.ReadOnlyUserPrefs;
 import profplan.model.task.Task;
 import profplan.testutil.Assert;
@@ -116,6 +118,26 @@ public class AddCommandTest {
 
         @Override
         public void setProfPlanFilePath(Path profPlanFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setUserConfigs(ReadOnlyUserConfigs userConfigs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserConfigs getUserConfigs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Settings getSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setSettings(Settings settings) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/profplan/logic/commands/ClearCommandTest.java
+++ b/src/test/java/profplan/logic/commands/ClearCommandTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import profplan.model.Model;
 import profplan.model.ModelManager;
 import profplan.model.ProfPlan;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.testutil.TypicalTasks;
 
@@ -22,8 +23,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyProfPlan_success() {
-        Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
-        Model expectedModel = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
+        Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
+        Model expectedModel = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
         expectedModel.setProfPlan(new ProfPlan());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/profplan/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/profplan/logic/commands/DeleteCommandTest.java
@@ -13,6 +13,7 @@ import profplan.commons.core.index.Index;
 import profplan.logic.Messages;
 import profplan.model.Model;
 import profplan.model.ModelManager;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.Task;
 import profplan.testutil.TypicalIndexes;
@@ -24,7 +25,7 @@ import profplan.testutil.TypicalTasks;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
+    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -34,7 +35,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TASK_SUCCESS,
                 Messages.format(taskToDelete));
 
-        ModelManager expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs(), new UserConfigs());
         expectedModel.deleteTask(taskToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
@@ -58,7 +59,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TASK_SUCCESS,
                 Messages.format(taskToDelete));
 
-        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs(), new UserConfigs());
         expectedModel.deleteTask(taskToDelete);
         showNoTask(expectedModel);
 

--- a/src/test/java/profplan/logic/commands/EditCommandTest.java
+++ b/src/test/java/profplan/logic/commands/EditCommandTest.java
@@ -13,6 +13,7 @@ import profplan.logic.commands.EditCommand.EditTaskDescriptor;
 import profplan.model.Model;
 import profplan.model.ModelManager;
 import profplan.model.ProfPlan;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.Task;
 import profplan.testutil.EditTaskDescriptorBuilder;
@@ -25,7 +26,7 @@ import profplan.testutil.TypicalTasks;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
+    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -35,7 +36,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, Messages.format(editedTask));
 
-        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs(), new UserConfigs());
         expectedModel.setTask(model.getFilteredTaskList().get(0), editedTask);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -57,7 +58,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, Messages.format(editedTask));
 
-        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs(), new UserConfigs());
         expectedModel.setTask(lastTask, editedTask);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -70,7 +71,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, Messages.format(editedTask));
 
-        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs(), new UserConfigs());
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -87,7 +88,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, Messages.format(editedTask));
 
-        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ProfPlan(model.getProfPlan()), new UserPrefs(), new UserConfigs());
         expectedModel.setTask(model.getFilteredTaskList().get(0), editedTask);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/profplan/logic/commands/FindCommandTest.java
+++ b/src/test/java/profplan/logic/commands/FindCommandTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import profplan.model.Model;
 import profplan.model.ModelManager;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.predicates.NameContainsKeywordsPredicate;
 import profplan.testutil.TypicalTasks;
@@ -21,8 +22,9 @@ import profplan.testutil.TypicalTasks;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
-    private Model expectedModel = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
+    private Model model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
+    private Model expectedModel = new ModelManager(TypicalTasks.getTypicalProfPlan(),
+            new UserPrefs(), new UserConfigs());
 
     @Test
     public void equals() {

--- a/src/test/java/profplan/logic/commands/ListCommandTest.java
+++ b/src/test/java/profplan/logic/commands/ListCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import profplan.model.Model;
 import profplan.model.ModelManager;
+import profplan.model.UserConfigs;
 import profplan.model.UserPrefs;
 import profplan.model.task.predicates.TaskInMonthPredicate;
 import profplan.model.task.predicates.TaskInWeekPredicate;
@@ -25,8 +26,8 @@ public class ListCommandTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs());
-        expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs());
+        model = new ModelManager(TypicalTasks.getTypicalProfPlan(), new UserPrefs(), new UserConfigs());
+        expectedModel = new ModelManager(model.getProfPlan(), new UserPrefs(), new UserConfigs());
     }
 
     @Test

--- a/src/test/java/profplan/model/ModelManagerTest.java
+++ b/src/test/java/profplan/model/ModelManagerTest.java
@@ -98,10 +98,11 @@ public class ModelManagerTest {
                 TypicalTasks.ALICE).withTask(TypicalTasks.BENSON).build();
         ProfPlan differentProfPlan = new ProfPlan();
         UserPrefs userPrefs = new UserPrefs();
+        UserConfigs userConfigs = new UserConfigs();
 
         // same values -> returns true
-        modelManager = new ModelManager(profPlan, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(profPlan, userPrefs);
+        modelManager = new ModelManager(profPlan, userPrefs, userConfigs);
+        ModelManager modelManagerCopy = new ModelManager(profPlan, userPrefs, userConfigs);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -114,12 +115,12 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentProfPlan, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentProfPlan, userPrefs, userConfigs)));
 
         // different filteredList -> returns false
         String[] keywords = TypicalTasks.ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredTaskList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(profPlan, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(profPlan, userPrefs, userConfigs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
@@ -127,6 +128,6 @@ public class ModelManagerTest {
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setProfPlanFilePath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new ModelManager(profPlan, differentUserPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(profPlan, differentUserPrefs, userConfigs)));
     }
 }

--- a/src/test/java/profplan/storage/StorageManagerTest.java
+++ b/src/test/java/profplan/storage/StorageManagerTest.java
@@ -26,7 +26,8 @@ public class StorageManagerTest {
     public void setUp() {
         JsonProfPlanStorage addressBookStorage = new JsonProfPlanStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonUserConfigsStorage userConfigsStorage = new JsonUserConfigsStorage(getTempFilePath("configs"));
+        storageManager = new StorageManager(addressBookStorage, userPrefsStorage, userConfigsStorage);
     }
 
     private Path getTempFilePath(String fileName) {


### PR DESCRIPTION
Adds a new command: `set`

Specifications: `set` allows the user to configure certain parameters defined in the file `settings.json` in the root folder. This file is saved to disk and the configurations persist across sessions.

Syntax: `set [setting] [inputValue]`

Current supported setting:
- `semesterDays`: Allows the user to specify the number of days in a semester, for recurring tasks. The default is `180`.

To add a new setting to this config, the classes that need to be updated are:
- `Settings` in `profplan\commons\core\index`
- `EditSettings` (nested class) in `EditSettingsCommand`
- `EditSettingsCommandParser`

Notes:
- In order to make the user configurations (which are stored in `ModelManager`) available to all classes to read from, the field `userConfigs` in `ModelManager` is `static`, with getters and setters for *both* the `userConfig` and the `settings` it contains.

Closes #136.