### PR TITLE
Fix settings validation

### DIFF
--- a/src/main/java/profplan/commons/core/Settings.java
+++ b/src/main/java/profplan/commons/core/Settings.java
@@ -20,6 +20,9 @@ public class Settings implements Serializable {
     // fields
     private final int semesterDays;
 
+    // misc.
+    public static final String SEMESTER_DAYS_CONSTRAINTS = "The parameter semesterDays must be a non-negative integer.";
+
     /**
      * Constructs a {@code Settings} with default settings.
      */

--- a/src/main/java/profplan/commons/core/Settings.java
+++ b/src/main/java/profplan/commons/core/Settings.java
@@ -11,17 +11,18 @@ import profplan.logic.parser.Prefix;
  * Guarantees: immutable.
  */
 public class Settings implements Serializable {
+
     // array containing all keywords used to specify these fields. contain these keywords in Prefixes.
     public static final Prefix[] KEYWORDS = {new Prefix("semesterDays")};
+
+    // misc.
+    public static final String SEMESTER_DAYS_CONSTRAINTS = "The parameter semesterDays must be a non-negative integer.";
 
     // default values
     private static final int DEFAULT_SEMESTER_DAYS = 180;
 
     // fields
     private final int semesterDays;
-
-    // misc.
-    public static final String SEMESTER_DAYS_CONSTRAINTS = "The parameter semesterDays must be a non-negative integer.";
 
     /**
      * Constructs a {@code Settings} with default settings.

--- a/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
+++ b/src/main/java/profplan/logic/parser/EditSettingsCommandParser.java
@@ -28,7 +28,7 @@ public class EditSettingsCommandParser implements Parser<EditSettingsCommand> {
         // semesterDays
         if (argumentMultimap.getValue(keywords[0]).isPresent()) {
             editSettingsDescriptor.setSemesterDays(ParserUtil
-                    .parseInteger(argumentMultimap.getValue(keywords[0]).get()));
+                    .parseSemesterDays(argumentMultimap.getValue(keywords[0]).get()));
         }
 
         return new EditSettingsCommand(editSettingsDescriptor);

--- a/src/main/java/profplan/logic/parser/ParserUtil.java
+++ b/src/main/java/profplan/logic/parser/ParserUtil.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import profplan.commons.core.Settings;
 import profplan.commons.core.index.Index;
 import profplan.commons.util.StringUtil;
 import profplan.logic.parser.exceptions.ParseException;
@@ -186,5 +187,21 @@ public class ParserUtil {
         } catch (NumberFormatException e) {
             throw new ParseException(e.getMessage());
         }
+    }
+
+    /**
+     * Checks if a String is a valid input value for the semesterDays setting and returns it if so.
+     */
+    public static int parseSemesterDays(String input) throws ParseException {
+        int parsedInteger = -1;
+        try {
+            parsedInteger = Integer.parseInt(input.trim());
+        } catch (NumberFormatException e) {
+            throw new ParseException("Could not parse an integer. " + e.getMessage());
+        }
+        if (parsedInteger < 0) {
+            throw new ParseException(Settings.SEMESTER_DAYS_CONSTRAINTS);
+        }
+        return parsedInteger;
     }
 }


### PR DESCRIPTION
Add input validation to `set semesterDays` so that it throws useful errors for invalid inputs. (Valid inputs are non-negative integers.)

Resolves #195, resolves #196.